### PR TITLE
Show source snippets in parser errors

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1214,15 +1214,17 @@ impl Analyzer {
 mod tests {
     use std::fs;
     use std::path::Path;
+    use std::sync::Arc;
 
     use crate::analyzer::Analyzer;
     use crate::lexer::Lexer;
     use crate::parser::Parser;
 
     fn analyze_source(source: &str) -> Result<(), String> {
-        let mut lexer = Lexer::new(source);
+        let source_arc: Arc<str> = Arc::from(source);
+        let mut lexer = Lexer::new(&source_arc);
         let tokens = lexer.tokenize();
-        let mut parser = Parser::new(tokens);
+        let mut parser = Parser::new(source_arc, tokens);
         let ast = parser.parse_file().map_err(|e| e.to_string())?;
         let analyzer = Analyzer::new(ast);
         analyzer.analyze()

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use std::env;
 use std::fs;
 use std::io;
 use std::path::Path;
+use std::sync::Arc;
 
 fn main() -> io::Result<()> {
     // コマンドライン引数からファイル名を取得
@@ -37,7 +38,7 @@ fn main() -> io::Result<()> {
 
     let filename = &filenames[0];
     // ファイルの内容を読み込む
-    let source_code = fs::read_to_string(filename)?;
+    let source_code: Arc<str> = Arc::from(fs::read_to_string(filename)?);
     // ===============================
     // 1. 字句解析 (Lexer)
     // ===============================
@@ -51,7 +52,7 @@ fn main() -> io::Result<()> {
     // ===============================
     // 2. 構文解析 (Parser)
     // ===============================
-    let mut parser = parser::Parser::new(tokens);
+    let mut parser = parser::Parser::new(source_code.clone(), tokens);
     let parse_result = match parser.parse_file() {
         Ok(ast) => {
             println!("\n--- Parsed AST ---");


### PR DESCRIPTION
## Summary
- carry the original source in the parser so parse errors can render a highlighted code snippet
- extend `ParserError` to include the snippet and update the CLI to print the formatted message
- pass source text to parser creation in inline-expression parsing and analyzer tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f78afa766c832dad3d5c4879ee358c